### PR TITLE
Update database-user-password.md

### DIFF
--- a/docs/guide/database-user-password.md
+++ b/docs/guide/database-user-password.md
@@ -20,7 +20,7 @@ The initial account password for the MongoDB is null. No initial account passwor
 
 ## Database Client
 
-For MySQL and MariaDB. FlyEnv has built-in PhoMyAdmin
+For MySQL and MariaDB. FlyEnv has built-in phpMyAdmin
 
 <img src="https://oss.macphpstudy.com/image/30d01fec0e6a.png" data-x-image-preview="">
 <p/>


### PR DESCRIPTION
fix phpMyAdmin Spelling Errors。In phpMyAdmin, "php" is typically written in lowercase (since PHP is an abbreviation, but when used as a prefix, it is customary to use lowercase).